### PR TITLE
Backport 2.0 Flag Status

### DIFF
--- a/addons/sourcemod/gamedata/tf2.bwrr.txt
+++ b/addons/sourcemod/gamedata/tf2.bwrr.txt
@@ -46,12 +46,6 @@
 				"windows"	"\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x2A\x89\x6C\x24\x2A\x8B\xEC\x81\xEC\xAC\x00\x00\x00"
 				"linux"		"@_ZN12CBaseTrigger13PointIsWithinERK6Vector"
 			}
-			"CCaptureFlag::IsHome" // CTFBotAttackFlagDefenders::Update // string --> "Flag was dropped"
-			{
-				"library"	"server"
-				"windows"	"\x8B\x89\x10\x02\x00\x00\x85\xC9"
-				"linux"		"@_ZN12CCaptureFlag6IsHomeEv"
-			}
 			"CMultiplayRules::HaveAllPlayersSpeakConceptIfAllowed" // string --> "MVM.SentryBusterExplode"
 			{
 				"library"	"server"

--- a/addons/sourcemod/scripting/bwrredux/functions.sp
+++ b/addons/sourcemod/scripting/bwrredux/functions.sp
@@ -26,6 +26,72 @@ enum eEngineerTeleportType
 	TeleportToAlly // Near ally
 }
 
+enum
+{
+	TF_FLAGINFO_HOME = 0, // Flag is at home
+	TF_FLAGINFO_STOLEN = (1<<0), // Flag is stolen
+	TF_FLAGINFO_DROPPED = (1<<1) // Flag is dropped
+};
+
+/**
+ * Gets a TF2 flag (item_teamflag) status.
+ *
+ * @param flag          Flag entity index.
+ * @return              Flag current status.
+ * @error               Invalid entity or entity is not a flag.
+ */
+stock int TF2_GetFlagStatus(int flag)
+{
+	if(!IsValidEntity(flag)) 
+	{ 
+		ThrowError("Invalid flag entity %i!", flag); 
+	}
+
+	if(!HasEntProp(flag, Prop_Send, "m_nFlagStatus"))
+	{
+		ThrowError("Entity %i does not have \"m_nFlagStatus\"!", flag);
+	}
+
+	return GetEntProp(flag, Prop_Send, "m_nFlagStatus");
+}
+
+/**
+ * Checks if a TF2 flag (item_teamflag) is home.
+ *
+ * @param flag          Flag entity index.
+ * @return              TRUE if the flag is home.
+ * @error               Invalid entity or entity is not a flag.
+ */
+stock bool TF2_IsFlagHome(int flag)
+{
+	return TF2_GetFlagStatus(flag) == TF_FLAGINFO_HOME;
+}
+
+/**
+ * Checks if a TF2 flag (item_teamflag) is stolen.
+ *
+ * @param flag          Flag entity index.
+ * @return              TRUE if the flag is stolen.
+ * @error               Invalid entity or entity is not a flag.
+ */
+stock bool TF2_IsFlagStolen(int flag)
+{
+	return TF2_GetFlagStatus(flag) == TF_FLAGINFO_STOLEN;
+}
+
+/**
+ * Checks if a TF2 flag (item_teamflag) is dropped.
+ *
+ * @param flag          Flag entity index.
+ * @return              TRUE if the flag is dropped.
+ * @error               Invalid entity or entity is not a flag.
+ */
+stock bool TF2_IsFlagDropped(int flag)
+{
+	return TF2_GetFlagStatus(flag) == TF_FLAGINFO_DROPPED;
+}
+
+
 /**
  * Checks if the given client index is valid.
  *
@@ -2334,17 +2400,6 @@ int TF2_GetClientFlag(int client)
 void TF2_PickUpFlag(int client, int flag)
 {
 	SDKCall(g_hSDKPickupFlag, flag, client, true);
-}
-
-/**
- * Checks if the flag is home
- *
- * @param flag		The flag entity index to check
- * @return     True if the given flag is at home
- */
-bool TF2_IsFlagHome(int flag)
-{
-	return SDKCall(g_hSDKIsFlagHome, flag);
 }
 
 /**

--- a/addons/sourcemod/scripting/tf_bwr_redux.sp
+++ b/addons/sourcemod/scripting/tf_bwr_redux.sp
@@ -24,7 +24,7 @@
 // visible weapons?
 //#define VISIBLE_WEAPONS
 
-#define PLUGIN_VERSION "1.2.16"
+#define PLUGIN_VERSION "1.2.17"
 
 // giant sounds
 #define ROBOT_SND_GIANT_SCOUT "mvm/giant_scout/giant_scout_loop.wav"
@@ -123,7 +123,6 @@ Handle g_hSDKWorldSpaceCenter;
 Handle g_hSDKRemoveObject;
 Handle g_hSDKGetMaxClip;
 Handle g_hSDKGetClip;
-Handle g_hSDKIsFlagHome;
 Handle g_hSDKPickupFlag;
 Handle g_hSDKSpeakConcept;
 Handle g_hSDKPushAwayPlayers;
@@ -533,12 +532,6 @@ public void OnPluginStart()
 	PrepSDKCall_SetFromConf(gd, SDKConf_Virtual, "CBaseEntity::WorldSpaceCenter");
 	PrepSDKCall_SetReturnInfo(SDKType_Vector, SDKPass_ByRef);
 	if((g_hSDKWorldSpaceCenter = EndPrepSDKCall()) == null) { LogError("Failed to create SDKCall for CBaseEntity::WorldSpaceCenter offset!"); sigfailure = true; }
-	
-	// Used to check if the bomb is at home
-	StartPrepSDKCall(SDKCall_Entity);
-	PrepSDKCall_SetFromConf(gd, SDKConf_Signature, "CCaptureFlag::IsHome");
-	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
-	if((g_hSDKIsFlagHome = EndPrepSDKCall()) == null) { LogError("Failed to create SDKCall for CCaptureFlag::IsHome signature!"); sigfailure = true; }
 	
 	// Make players speak concept
 	StartPrepSDKCall(SDKCall_GameRules);


### PR DESCRIPTION
Backports BWRR 2.0 flag status function since they don't need gamedata to function and shouldn't break with TF2 updates unless valve changes the netprop used.

Should fix #14 