### PR TITLE
FakeClient team check

### DIFF
--- a/addons/sourcemod/scripting/tf_bwr_redux.sp
+++ b/addons/sourcemod/scripting/tf_bwr_redux.sp
@@ -3697,7 +3697,7 @@ public Action E_Pre_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 public Action E_PlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(event.GetInt("userid"));
-	if( IsFakeClient(client) ) {
+	if( IsFakeClient(client) && TF2_GetClientTeam(client) == TFTeam_Blue ) {
 		CreateTimer(1.0, Timer_OnFakePlayerSpawn, client, TIMER_FLAG_NO_MAPCHANGE);
 	}
 	else {


### PR DESCRIPTION
This change adds a small check to ensure that Blu bots are only teleported to Robot Engineer's teleporters, this will prevent Red bots from teleporting to the Blu teleporter.